### PR TITLE
end streams on error so that the node process exits on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,11 @@ function promiseFromStreams(streams) {
 
     streams.forEach((stream, i) => {
 
-      stream.on('error', reject)
+      stream.on('error', error => {
+
+        stream.end()
+        reject(error)
+      })
 
       if(i === streams.length - 1) {
 


### PR DESCRIPTION
We can't really do anything if one of the streams errors, so just end the stream.